### PR TITLE
Version bump and Grok versions file reference change

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,18 @@
 Changes
 =======
 
-2.10 (unreleased)
+2.11 (Unreleased)
+-----------------
+- Nothing changed
+
+
+2.10 (2017-10-24)
 -----------------
 
-- Nothing changed yet.
+- Fixed improper references to old svn based versions directory for latest 
+  Grok version information.
+- Some minor fixes to test procedures to make tests (and Travis-CI) work again.
+- Some Python-3 prep work.
 
 
 2.9 (2013-02-14)

--- a/grokproject/templates.py
+++ b/grokproject/templates.py
@@ -21,7 +21,7 @@ from grokproject.utils import exist_buildout_default_file
 # base = base[base.find('url = ')+6:base.find('.git')]
 # base = base.replace('github.com', 'raw.githubusercontent.com')
 
-base = 'https://raw.githubusercontent.com/prsephton/grokproject'
+base = 'https://raw.githubusercontent.com/zopefoundation/grokproject'
 GROK_RELEASE_URL = base + '/master/versions/'
 
 class GrokProject(templates.Template):


### PR DESCRIPTION
Bumped version info to 2.11, tagged 2.10, and changed reference for version directory to zopefoundation/grokproject/versions.