### PR TITLE
six urllib behaviour correction for version data

### DIFF
--- a/grokproject/templates.py
+++ b/grokproject/templates.py
@@ -143,10 +143,6 @@ class GrokProject(templates.Template):
             print("Error: cannot download required %s" % url)
             print("Server may be down.  Please try again later.")
             sys.exit(1)
-        if isinstance(contents, str):
-            contents = xml.sax.saxutils.quoteattr(contents)
-        else:
-            contents = xml.sax.saxutils.quoteattr(contents.decode())
         return contents
 
     def post(self, command, output_dir, vars):


### PR DESCRIPTION
The use of urllib as imported via six differs in its returned result from Python2.7 urllib2.   This patch fixes the issue.