### PR TITLE
Pin PasteScript version to zopetoolkit/1.1.4/ztk-versions.cfg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['PasteScript>=1.6'],
+    install_requires=['PasteScript==1.7.5'],
     test_suite='tests.test_suite',
     entry_points={
         'console_scripts': ['grokproject = grokproject:main'],


### PR DESCRIPTION
Pin PasteScript version to the same one in zopetoolkit/1.1.4/ztk-versions.cfg

This prevents the version clash cause by an open ended version while installing grokproject